### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group = com.enonic.app
 projectName = discussion
 appName = com.enonic.app.discussion
 xpVersion = 8.0.0-B4
-version = 2.1.0-SNAPSHOT
+version = 3.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

- Bumps `version` in `gradle.properties` from `2.1.0-SNAPSHOT` to `3.0.0-SNAPSHOT` to open the XP 8 line on master.
- Adds a `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `2.x` so the release tooling recognizes both as release branches.
- Companion PR on the new `2.x` maintenance branch (cut from `e0b2e88`, the post-`v2.0.0` `2.1.0-SNAPSHOT` commit) adds the same `releaseBranch:` block on that branch — required because the action reads `releaseBranch:` from the branch's own workflow file.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: `./gradlew clean build` from master is green