### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -1,0 +1,29 @@
+name: Gradle Build
+
+on: [ push ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.build-and-publish.outputs.release }}
+    steps:
+      - id: build-and-publish
+        uses: enonic/release-tools/build-and-publish@master
+        with:
+          repoUser: ci
+          repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
+
+  release:
+    runs-on: ubuntu-latest
+
+    needs: build
+    if: needs.build.outputs.release == 'true'
+
+    steps:
+      - uses: enonic/release-tools/release@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/enonic-gradle.yml` on the new `2.x` maintenance branch (the workflow file did not exist at the source commit `e0b2e88`, which was the post-`v2.0.0` `2.1.0-SNAPSHOT` bump).
- Includes a `releaseBranch:` block listing both `master` and `2.x` so pushes to `2.x` are classified as release-branch builds.
- The action reads `releaseBranch:` from the branch's own workflow file, which is why this PR is required in addition to the master-side PR.
- No version bump, no other changes — those are master-only.

## Test plan

- [ ] CI run on this PR / on `2.x` after merge classifies `2.x` as a release branch