### PR TITLE
Migrate to lib-asset #37

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     include xplibs.repo
 
     include "com.enonic.lib:lib-thymeleaf:3.0.0-SNAPSHOT"
+    include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"
     //include 'openxp.lib:appersist:1.0.0'
 }
 

--- a/src/main/resources/cms/parts/comment-field/comment-field.js
+++ b/src/main/resources/cms/parts/comment-field/comment-field.js
@@ -1,4 +1,5 @@
 var portal = require("/lib/xp/portal");
+var assetLib = require("/lib/enonic/asset");
 var contentLib = require("/lib/xp/content");
 var thymeleaf = require("/lib/thymeleaf");
 var commentLib = require("/lib/commentManager");
@@ -60,21 +61,21 @@ exports.get = function (ref) {
     var view = resolve("comment-field.html");
 
     var addition = [
-        "<script src='" + portal.assetUrl({ path: "script/lib/jquery-3.3.1.min.js" }) + "'></script>",
+        "<script src='" + assetLib.assetUrl({ path: "script/lib/jquery-3.3.1.min.js" }) + "'></script>",
     ];
 
     var siteConfig = portal.getSiteConfig();
 
     if (siteConfig.defaultStyle) {
-        addition.push("<link rel='stylesheet' href='" + portal.assetUrl({ path: "css/default.css" }) + "'/>");
-    }    
+        addition.push("<link rel='stylesheet' href='" + assetLib.assetUrl({ path: "css/default.css" }) + "'/>");
+    }
 
     return {
         body: thymeleaf.render(view, model),
         pageContributions: {
             headEnd: addition,
             bodyEnd: [
-                "<script src='" + portal.assetUrl({ path: "script/comment-post.js" }) + "'></script>",
+                "<script src='" + assetLib.assetUrl({ path: "script/comment-post.js" }) + "'></script>",
             ]
         }
     };

--- a/src/main/resources/cms/parts/latest/latest.js
+++ b/src/main/resources/cms/parts/latest/latest.js
@@ -3,6 +3,7 @@ var commentLib = require("/lib/commentManager");
 var contentLib = require("/lib/xp/content");
 var nodeLib = require('/lib/xp/node');
 var portal = require('/lib/xp/portal');
+var assetLib = require('/lib/enonic/asset');
 var i18n = require('/lib/xp/i18n');
 //var tools = require('/lib/tools');
 
@@ -84,7 +85,7 @@ exports.get = function (req) {
     var siteConfig = portal.getSiteConfig();
 
     if (siteConfig.defaultStyle) {
-        addition.push("<link rel='stylesheet' href='" + portal.assetUrl({ path: "css/default.css" }) + "'/>");
+        addition.push("<link rel='stylesheet' href='" + assetLib.assetUrl({ path: "css/default.css" }) + "'/>");
     }
 
     return {

--- a/src/main/resources/cms/site.yaml
+++ b/src/main/resources/cms/site.yaml
@@ -1,1 +1,3 @@
 kind: "Site"
+apis:
+  - "asset"


### PR DESCRIPTION
## Summary

- Replaces deprecated `portal.assetUrl` calls in `cms/parts/latest/latest.js` and `cms/parts/comment-field/comment-field.js` with `assetLib.assetUrl` from `/lib/enonic/asset`.
- Adds `com.enonic.lib:lib-asset:2.0.0-SNAPSHOT` to `build.gradle`.
- Registers the asset Universal API on `cms/site.yaml` via `apis: ["asset"]` — both call sites run in site context, so lib-asset is the right target (lib-static is reserved for ID providers / admin extensions / universal APIs that lib-asset doesn't cover).

Closes #37

## Test plan

- [x] `./gradlew build --refresh-dependencies` clean
- [x] Bundle reaches `ACTIVE` after deploy (`Started application com.enonic.app.discussion bundle 117` in `server.log`)
- [x] Asset API mount on the discussion site verified end-to-end inside `claude-dev` (XP `8.0.0-SNAPSHOT`):
  - `/site/default/master/testdiscussion/_/com.enonic.app.discussion:asset/<fp>/css/default.css` → **200 OK**, `text/css`, 1853 bytes
  - `/site/default/master/testdiscussion/_/com.enonic.app.discussion:asset/<fp>/script/lib/jquery-3.3.1.min.js` → **200 OK**, `application/javascript`, 86927 bytes
  - `/site/default/master/testdiscussion/_/com.enonic.app.discussion:asset/<fp>/script/comment-post.js` → **200 OK**, `application/javascript`, 5611 bytes
- [x] No remaining `portal.assetUrl` calls (`grep -rn "portal.assetUrl" src/` → empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)