### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ dependencies {
     include xplibs.auth
     include xplibs.repo
 
-    include "com.enonic.lib:lib-thymeleaf:3.0.0-SNAPSHOT"
-    include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"
+    include libs.lib.thymeleaf
+    include libs.lib.asset
     //include 'openxp.lib:appersist:1.0.0'
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,7 @@
+[versions]
+asset = "2.0.0-SNAPSHOT"
+thymeleaf = "3.0.0-SNAPSHOT"
+
+[libraries]
+lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }
+lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }


### PR DESCRIPTION
## Summary

Move the two inline-versioned `com.enonic.lib:*` dependencies in `build.gradle` into a new `gradle/libs.versions.toml` catalog. This unifies `app-discussion` with the half of the IdeaProjects tree that already keeps versions in a catalog, so bulk dependency bumps (e.g. XP 8 SNAPSHOTs) can target one file per repo with a consistent shape.

Pin-for-pin migration — no version changes.

## Conventions adopted

- `[versions]` and `[libraries]` sorted alphabetically.
- Short, lowercase, hyphen-separated keys.
- `xpVersion` stays in `gradle.properties` as a regular Gradle property (per task brief — the rest of the toolchain expects it there).
- `xplibs.*` accessors and BOM-style XP includes are left untouched.

## Catalog content

```toml
[versions]
asset = "2.0.0-SNAPSHOT"
thymeleaf = "3.0.0-SNAPSHOT"

[libraries]
lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }
lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }
```

## Verification

- `./gradlew clean build --refresh-dependencies` → `BUILD SUCCESSFUL`
- `./gradlew dependencies --configuration runtimeClasspath` diffed against pre-migration HEAD → identical resolved tree.
- Built `discussion.jar` still bundles `com/enonic/lib/asset/**` and `com/enonic/lib/thymeleaf/**` classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)